### PR TITLE
Lecturer should copy the quarterweeks hyperlink for subscription

### DIFF
--- a/www/js/roosterious.js
+++ b/www/js/roosterious.js
@@ -314,23 +314,32 @@ function loadExt(extType) {
       window.location = "api/schedule/" + currentScheduleType + "/" + currentScheduleId + ".json";
     } else if (extType == "csv") {
       window.location = "api/schedule/" + currentScheduleType + "/" + currentScheduleId + ".csv";
-    }
+    } 
   } else {
-    alert("Kies eerst een rooster");  
+    alert("Kies eerst een rooster");
   }
 }
 
 //Copy link to external file to clipboard
 function copyExt(extType) {
-	var url = "http://www.roosterious.nl/";
-	if (extType == "iCal") {
-      url += "api/schedule/" + currentScheduleType + "/" + currentScheduleId + ".ical";
-    } else if (extType == "json") {
-      url += "api/schedule/" + currentScheduleType + "/" + currentScheduleId + ".json";
-    } else if (extType == "csv") {
-      url += "api/schedule/" + currentScheduleType + "/" + currentScheduleId + ".csv";
-    }
-    
-    $('#copyexturl').html(url);
-    $('#copyext').modal({});
+	// currentScheduleType = "lecturer"
+	// currentScheduleId = "rja01"
+	if (currentScheduleType != "") {
+		if (extType == "qw"){
+			var url = "http://quarterweeks.herokuapp.com/" + currentScheduleId;
+		} else {
+			var url = "http://www.roosterious.nl/";
+			if (extType == "iCal") {
+		      url += "api/schedule/" + currentScheduleType + "/" + currentScheduleId + ".ical";
+		  } else if (extType == "json") {
+		    url += "api/schedule/" + currentScheduleType + "/" + currentScheduleId + ".json";
+		  } else if (extType == "csv") {
+		    url += "api/schedule/" + currentScheduleType + "/" + currentScheduleId + ".csv";
+		  }
+		}
+  	$('#copyexturl').html(url);
+		$('#copyext').modal({});
+	} else {
+  	alert("Kies eerst een rooster");
+	}
 }

--- a/www/pages/schedule.php
+++ b/www/pages/schedule.php
@@ -66,6 +66,7 @@
         <div class="panel-heading">
           <span>&nbsp;</span>
           <div class="pull-right">
+						<a id="qw" href="#" onClick="copyExt('qw');" target="blank" class="btn btn-xs btn-default" role="button"></a>
             <div class="btn-group">
                 <button type="button" class="btn btn-default btn-xs dropdown-toggle" data-toggle="dropdown">
                     Download rooster
@@ -113,7 +114,7 @@
         $("#unitselectorview").show();
         $("#searcharea").addClass("panel-red");
         $("#schedulearea > div:first > span").html("Lesrooster van <strong>niemand</strong>. Kies hierhoven een docent");
-        
+        $("a#qw").html("Download kwartielweken");
         placeholdertext = "Klik om een docent te zoeken";
       } else if (type == "class") {
         $("#searcharea > div:first").html("Toon rooster van klas");


### PR DESCRIPTION
Beste Ruud,

Dit is mijn kleine bijdrage aan Roosterious, zodat docenten, via een vergelijkbare wijze in Roosterious, kunnen abonneren op een overzicht in hun favoriete kalender applicatie met daarin de veel gebruikte kwartiel-weeknummers.

De informatie, om aan de actuele kwartiel-weeknummers te komen, schraap ik (per opgegeven docent) van de website roosters.saxion.nl

De toevoegingen in deze pull request, maakt gebruik van mijn Ieniemienie-micro-service `quarterweeks`. Die is benaderbaar via: `quarterweeks.herokuapp.com/<docentencode>`

Als de opgegeven docentencode klopt, geeft het een `ics` bestand terug aan de eindgebruiker met week-events. Elke week-event bevat een kwartiel-weeknummer.

Voorbeeld:
http://quarterweeks.herokuapp.com/RGR05

Een aantal van mijn collega's maken er inmiddels enthousiast gebruik van. Dus het leek mij wel een goed idee om het toe te voegen aan Roosterious.

Laat me weten wat je hiervan vindt en of je het gaat mergen.

Groeten van je ACT collega,
Robin Janse
Saxion Docent Web
ACT/MIC
